### PR TITLE
Add aozora bank pay method

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -83,6 +83,7 @@ module GMO
       :pa_res                => "PaRes",
       :pay_times             => "PayTimes",
       :pay_type              => "PayType",
+      :payment_type          => "PaymentType",
       :payment_term_day      => "PaymentTermDay",
       :payment_term_sec      => "PaymentTermSec",
       :receipts_disp_1       => "ReceiptsDisp1",

--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -130,6 +130,7 @@ module GMO
       :token                 => "Token",
       :token_seq             => "TokenSeq",
       :token_type            => "TokenType",
+      :tradedays             => "TradeDays"
       :error_rcv_url         => "ErrorRcvURL",
       :product_name          => "ProductName",
       :product_image_url     => "ProductImageUrl",

--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -130,7 +130,7 @@ module GMO
       :token                 => "Token",
       :token_seq             => "TokenSeq",
       :token_type            => "TokenType",
-      :tradedays             => "TradeDays"
+      :tradedays             => "TradeDays",
       :error_rcv_url         => "ErrorRcvURL",
       :product_name          => "ProductName",
       :product_image_url     => "ProductImageUrl",

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -224,7 +224,7 @@ module GMO
       # 20.1.2.2. 決済実行
       def exec_tran_aozora(options = {})
         name = "ExecTranGANB.idPass"
-        required = [:access_id, :access_pass, :order_id, :TradeDays]
+        required = [:access_id, :access_pass, :order_id, :tradedays]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -196,7 +196,7 @@ module GMO
       # お客様が入力した情報で後続の決済センターと通信を行い決済を実施し、結果を返します。
       def exec_tran_pay_easy(options = {})
         name = "ExecTranPayEasy.idPass"
-        required = [:access_id, :access_pass, :order_id, :customer_name, :customer_kana, :tel_no, :receipts_disp_11, :receipts_disp_12, :receipts_disp_13]
+        required = [:access_id, :access_pass, :order_id, :customer_name, :customer_kana, :tel_no, :receipts_disp_11, :receipts_disp_12, :receipts_disp_13, :payment_type]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -224,7 +224,7 @@ module GMO
       # 20.1.2.2. 決済実行
       def exec_tran_aozora(options = {})
         name = "ExecTranGANB.idPass"
-        required = [:access_id, :access_pass, :order_id]
+        required = [:access_id, :access_pass, :order_id, :TradeDays]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -83,6 +83,16 @@ module GMO
         post_request name, options
       end
 
+      # 【あおぞら銀行バーチャル口座決済】
+      #  20.1.2.1. 取引登録
+      #  これ以降の決済取引で必要となる取引IDと取引パスワードの発行を行い、取引を開始します。
+      def entry_tran_aozora(options = {})
+        name = "EntryTranGANB.idPass"
+        required = [:order_id, :amount]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
       ### @params ###
       # OrderID
       # JobCd
@@ -206,6 +216,15 @@ module GMO
       def exec_tran_linepay(options = {})
         name = "ExecTranLinepay.idPass"
         required = [:access_id, :access_pass, :order_id, :ret_url, :error_rcv_url, :product_name]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
+      # 【あおぞら銀行バーチャル口座決済】
+      # 20.1.2.2. 決済実行
+      def exec_tran_aozora(options = {})
+        name = "ExecTranGANB.idPass"
+        required = [:access_id, :access_pass, :order_id]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -196,7 +196,7 @@ module GMO
       # お客様が入力した情報で後続の決済センターと通信を行い決済を実施し、結果を返します。
       def exec_tran_pay_easy(options = {})
         name = "ExecTranPayEasy.idPass"
-        required = [:access_id, :access_pass, :order_id, :customer_name, :customer_kana, :tel_no, :receipts_disp_11, :receipts_disp_12, :receipts_disp_13, :payment_type]
+        required = [:access_id, :access_pass, :order_id, :customer_name, :customer_kana, :tel_no, :receipts_disp_11, :receipts_disp_12, :receipts_disp_13]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -83,7 +83,7 @@ module GMO
         post_request name, options
       end
 
-      # 【あおぞら銀行バーチャル口座決済】
+      # 【あおぞら銀行決済】
       #  20.1.2.1. 取引登録
       #  これ以降の決済取引で必要となる取引IDと取引パスワードの発行を行い、取引を開始します。
       def entry_tran_aozora(options = {})
@@ -220,7 +220,7 @@ module GMO
         post_request name, options
       end
 
-      # 【あおぞら銀行バーチャル口座決済】
+      # 【あおぞら銀行決済】
       # 20.1.2.2. 決済実行
       def exec_tran_aozora(options = {})
         name = "ExecTranGANB.idPass"


### PR DESCRIPTION
**あおぞら銀行バーチャル口座決済メソッド追加**
取引登録のメソッドと口座情報返却のメソッドの２つを実装

**備考**
消したメソッドがないので特にない。